### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,47 +12,47 @@ RTCZero	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getDay					KEYWORD2
-getMonth				KEYWORD2
-getYear					KEYWORD2
-getHours 				KEYWORD2
-getMinutes			KEYWORD2
-getSeconds 			KEYWORD2
+getDay	KEYWORD2
+getMonth	KEYWORD2
+getYear	KEYWORD2
+getHours	KEYWORD2
+getMinutes	KEYWORD2
+getSeconds	KEYWORD2
 
-setDay					KEYWORD2
-setMonth				KEYWORD2
-setYear					KEYWORD2
-setHours 				KEYWORD2
-setMinutes			KEYWORD2
-setSeconds 			KEYWORD2
-setDate					KEYWORD2
-setTime					KEYWORD2
+setDay	KEYWORD2
+setMonth	KEYWORD2
+setYear	KEYWORD2
+setHours	KEYWORD2
+setMinutes	KEYWORD2
+setSeconds	KEYWORD2
+setDate	KEYWORD2
+setTime	KEYWORD2
 
-getEpoch			KEYWORD2
-getY2kEpoch			KEYWORD2
-setEpoch			KEYWORD2
-setY2kEpoch			KEYWORD2
+getEpoch	KEYWORD2
+getY2kEpoch	KEYWORD2
+setEpoch	KEYWORD2
+setY2kEpoch	KEYWORD2
 
-getAlarmDay			KEYWORD2
-getAlarmMonth		KEYWORD2
-getAlarmYear		KEYWORD2
-getAlarmHours 	KEYWORD2
+getAlarmDay	KEYWORD2
+getAlarmMonth	KEYWORD2
+getAlarmYear	KEYWORD2
+getAlarmHours	KEYWORD2
 getAlarmMinutes	KEYWORD2
-getAlarmSeconds KEYWORD2
+getAlarmSeconds	KEYWORD2
 
-setAlarmDay			KEYWORD2
-setAlarmMonth		KEYWORD2
-setAlarmYear		KEYWORD2
-setAlarmHours 	KEYWORD2
+setAlarmDay	KEYWORD2
+setAlarmMonth	KEYWORD2
+setAlarmYear	KEYWORD2
+setAlarmHours	KEYWORD2
 setAlarmMinutes	KEYWORD2
-setAlarmSeconds KEYWORD2
-setAlarmDate		KEYWORD2
-setAlarmTime		KEYWORD2
+setAlarmSeconds	KEYWORD2
+setAlarmDate	KEYWORD2
+setAlarmTime	KEYWORD2
 
-enableAlarm 		KEYWORD2
-disableAlarm 		KEYWORD2
+enableAlarm	KEYWORD2
+disableAlarm	KEYWORD2
 
-standbyMode			KEYWORD2
+standbyMode	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords